### PR TITLE
Fix truncated Omnisearch results block in Google search results

### DIFF
--- a/dist/obsidian-omnisearch-google.user.js
+++ b/dist/obsidian-omnisearch-google.user.js
@@ -4,7 +4,7 @@
 // @namespace    https://github.com/scambier/userscripts
 // @downloadURL  https://github.com/scambier/userscripts/raw/master/dist/obsidian-omnisearch-google.user.js
 // @updateURL    https://github.com/scambier/userscripts/raw/master/dist/obsidian-omnisearch-google.user.js
-// @version      0.3.4
+// @version      0.3.5
 // @description  Injects Obsidian notes in Google search results
 // @author       Simon Cambier
 // @match        https://google.com/*

--- a/dist/obsidian-omnisearch-google.user.js
+++ b/dist/obsidian-omnisearch-google.user.js
@@ -188,7 +188,7 @@
     init.then(() => {
         // Make sure the results container is there
         if (!$(sidebarSelector)[0]) {
-            $("#rcnt").append('<div id="rhs"></div>');
+            $("#rcnt").append('<div id="rhs" class="TQc1id k5T88b vVVcqf e0KErc"></div>');
         }
         injectResultsContainer();
         injectTitle();

--- a/src/obsidian-omnisearch-google.user.ts
+++ b/src/obsidian-omnisearch-google.user.ts
@@ -216,7 +216,7 @@
   init.then(() => {
     // Make sure the results container is there
     if (!$(sidebarSelector)[0]) {
-      $("#rcnt").append('<div id="rhs"></div>');
+      $("#rcnt").append('<div id="rhs" class="TQc1id k5T88b vVVcqf e0KErc"></div>');
     }
 
     injectResultsContainer();

--- a/src/obsidian-omnisearch-google.user.ts
+++ b/src/obsidian-omnisearch-google.user.ts
@@ -3,7 +3,7 @@
 // @namespace    https://github.com/scambier/userscripts
 // @downloadURL  https://github.com/scambier/userscripts/raw/master/dist/obsidian-omnisearch-google.user.js
 // @updateURL    https://github.com/scambier/userscripts/raw/master/dist/obsidian-omnisearch-google.user.js
-// @version      0.3.4
+// @version      0.3.5
 // @description  Injects Obsidian notes in Google search results
 // @author       Simon Cambier
 // @match        https://google.com/*


### PR DESCRIPTION
## Problem
As described in https://github.com/scambier/obsidian-omnisearch/issues/458, the Omnisearch results block on Google search results page is visibly distorted — the content appears compressed into a narrow column, even though all results are correctly injected into the DOM.

This happens because the dynamically created `#rhs` element (Google’s right sidebar) lacks the required layout classes used by Google to make the sidebar expand properly.

## Solution
When the script creates the #rhs element (in case it doesn't exist), add the same CSS classes that Google normally applies to this element.